### PR TITLE
feat : add message structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 option(ENABLE_TESTING "Enable Test Builds" ON)
 
 add_subdirectory(utils)
-
+add_subdirectory(communication)
 
 add_executable(${PROJECT_NAME} main.cpp)
 

--- a/communication/CMakeLists.txt
+++ b/communication/CMakeLists.txt
@@ -1,0 +1,30 @@
+add_library(communication)
+
+file(GLOB_RECURSE HEADER_FILES 
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/*.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp
+)
+
+file(GLOB_RECURSE SOURCE_FILES 
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp
+)
+
+target_sources(communication
+    PUBLIC
+        ${HEADER_FILES}
+    PRIVATE
+        ${SOURCE_FILES}
+)
+
+target_include_directories(communication
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+target_link_libraries(communication
+    PUBLIC
+        utils
+)
+
+message(STATUS "Headers: ${HEADER_FILES}")
+message(STATUS "Sources: ${SOURCE_FILES}")

--- a/communication/include/message.h
+++ b/communication/include/message.h
@@ -12,7 +12,7 @@ enum class MessageType : uint8_t {
   RESYNC = 0x03
 };
 
-enum class code : uint8_t {
+enum class Code : uint8_t {
   NONE = 0x00,
   TIMING_ERROR = 0x01,
   BUFFER_OVERFLOW = 0x02,

--- a/communication/include/message.h
+++ b/communication/include/message.h
@@ -1,0 +1,186 @@
+#pragma once
+#include <cassert>
+#include <cstring>
+#include <array>
+#include <algorithm>
+#include "logger.h"
+
+enum class MessageType : uint8_t {
+  SYNC = 0x00,
+  MOTOR_COMMAND = 0x01,
+  MOTOR_STATE = 0x02,
+  RESYNC = 0x03
+};
+
+enum class code : uint8_t {
+  NONE = 0x00,
+  TIMING_ERROR = 0x01,
+  BUFFER_OVERFLOW = 0x02,
+  INVALID_COMMAND = 0x03,
+  MOTOR_FAULT = 0x04,
+  SYNC_LOST = 0x05,
+  CRC_ERROR = 0x06,
+  EMERGENCY_STOP = 0x07
+};
+
+#pragma pack(push, 1)
+struct MotorCommand {
+  uint8_t motor_id;
+  uint8_t motor_speed_x;
+  uint8_t motor_speed_y;
+  uint8_t motor_speed;
+};
+
+struct MotorState {
+  uint8_t motor_id;
+  uint8_t current_speed;
+  uint8_t error_flags;
+};
+
+struct Sync {
+  uint32_t sync_counter;
+};
+
+struct MessageHeader {
+  uint8_t frame_start;
+  uint32_t timestamp_ns;
+  MessageType msg_type;
+  uint32_t payload_length;
+} __attribute__((packed));
+
+struct MessageFooter {
+  uint16_t checksum; // 2 bytes
+  uint8_t frame_end;
+} __attribute__((packed));
+
+struct Message {
+  static constexpr uint8_t FRAME_START_MARKER = 0xAA;
+  static constexpr uint8_t FRAME_END_MARKER = 0xFF;
+  static constexpr uint8_t BUFER_CAPACITY = 255;
+
+  // sizes 
+  static const uint8_t HEADER_SIZE = sizeof(MessageHeader);
+  static const uint8_t FOOTER_SIZE = sizeof(MessageFooter);
+  static constexpr size_t MAX_PAYLOAD_LENGTH = BUFER_CAPACITY - HEADER_SIZE - FOOTER_SIZE;
+
+  // buffer offsets 
+  static constexpr size_t FRAME_START_OFFSET = 0;
+  static constexpr size_t HEADER_OFFSET = FRAME_START_OFFSET;
+  static constexpr size_t PAYLOAD_OFFSET = HEADER_OFFSET + HEADER_SIZE;
+
+  size_t total_length = 0;
+  MessageHeader header;
+  uint8_t payload[BUFER_CAPACITY];
+  MessageFooter footer;
+
+  Message(uint32_t _timestamp_us, MessageType _type) {
+    header.timestamp_ns = _timestamp_us;
+    header.msg_type = _type;
+    memset(payload, 0, BUFER_CAPACITY);
+  }
+
+  int serialize(const void* data, uint8_t length) {
+    assert(length < MAX_PAYLOAD_LENGTH && "Payload is too large");
+
+    // Set the header fields
+    header.frame_start = FRAME_START_MARKER;
+    header.payload_length = length;
+    assert(header.timestamp_ns > 0 && "Timestamp not set");
+
+    // header
+    memcpy(payload + HEADER_OFFSET, &header, HEADER_SIZE);
+
+    // payload
+    memcpy(payload + PAYLOAD_OFFSET, data, length);
+
+    // Calculate checksum over payload only
+    footer.checksum = calculate_crc();
+    footer.frame_end = FRAME_END_MARKER;
+
+    // Write footer
+    size_t footer_offset = PAYLOAD_OFFSET + length;
+    memcpy(payload + footer_offset, &footer, FOOTER_SIZE);
+
+    total_length = HEADER_SIZE + length + FOOTER_SIZE;
+    return total_length;
+  }
+
+  uint16_t calculate_crc() {
+    uint16_t crc = 0;
+    const uint8_t* payload_data = payload + PAYLOAD_OFFSET;
+    for (size_t i = 0; i < header.payload_length; i++) {
+      crc ^= payload_data[i];
+    }
+    return crc;
+  }
+
+  MessageHeader get_header() {
+    MessageHeader hdr;
+    memcpy(&hdr, payload + HEADER_OFFSET, HEADER_SIZE);
+    return hdr;
+  }
+
+  MessageFooter get_footer() {
+    MessageFooter ftr;
+    size_t footer_offset = PAYLOAD_OFFSET + header.payload_length;
+    memcpy(&ftr, payload + footer_offset, FOOTER_SIZE);
+    return ftr;
+  }
+
+  void deserialize(void* msg_struct, uint8_t length) {
+    assert(length <= header.payload_length && "Requested length larger than payload");
+    memcpy(msg_struct, payload + PAYLOAD_OFFSET, length);
+  }
+
+  void hex_dump() {
+    printf("\nMessage Hex Dump:\n");
+    printf("Total Length: %zu bytes\n", total_length);
+
+    printf("Header (%u bytes):", HEADER_SIZE);
+    for (size_t i = 0; i < HEADER_SIZE; i++) {
+      if (i % 8 == 0) printf("\n  ");
+      printf("%02X ", payload[HEADER_OFFSET + i]);
+    }
+
+    printf("\nPayload (%u bytes):", header.payload_length);
+    for (size_t i = 0; i < header.payload_length; i++) {
+      if (i % 8 == 0) printf("\n  ");
+      printf("%02X ", payload[PAYLOAD_OFFSET + i]);
+    }
+
+    printf("\nFooter (%u bytes):", FOOTER_SIZE);
+    size_t footer_offset = PAYLOAD_OFFSET + header.payload_length;
+    for (size_t i = 0; i < FOOTER_SIZE; i++) {
+      if (i % 8 == 0) printf("\n  ");
+      printf("%02X ", payload[footer_offset + i]);
+    }
+    printf("\n");
+  }
+
+  void print_debug() {
+    printf("\n=== Message Debug Information ===\n");
+    printf("Structure:\n");
+    printf("  Total Length: %zu bytes\n", total_length);
+    printf("  Header Size: %u bytes\n", HEADER_SIZE);
+    printf("  Payload Length: %u bytes\n", header.payload_length);
+    printf("  Footer Size: %u bytes\n", FOOTER_SIZE);
+
+    printf("\nHeader Details:\n");
+    printf("  Frame Start: 0x%02X %s\n", header.frame_start,
+      header.frame_start == FRAME_START_MARKER ? "(Valid)" : "(Invalid)");
+    printf("  Timestamp: %u ns\n", header.timestamp_ns);
+    printf("  Type: 0x%02X\n", static_cast<uint8_t>(header.msg_type));
+
+    printf("\nFooter Details:\n");
+    MessageFooter ftr = get_footer();
+    printf("  Checksum: 0x%04X\n", ftr.checksum);
+    printf("  Frame End: 0x%02X %s\n", ftr.frame_end,
+      ftr.frame_end == FRAME_END_MARKER ? "(Valid)" : "(Invalid)");
+
+    printf("\nBuffer Content:\n");
+    hex_dump();
+    printf("=== End Debug Info ===\n\n");
+  }
+};
+
+#pragma pack(pop)

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,4 @@
 #include "logger.h"
 int main() {
-    newton::Logger::LOG_INFO("Motors", "Speed: {:.2f} RPM", 123.456);
     return 0;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,11 +2,13 @@ find_package(Catch2 3 REQUIRED)
 
 add_executable(tests
   utils/test_logger.cpp
+  utils/test_message.cpp
 )
 
 target_link_libraries(tests
     PRIVATE
         utils
+        communication
         Catch2::Catch2WithMain
 )
 
@@ -17,3 +19,4 @@ target_include_directories(tests
 
 include(Catch)
 catch_discover_tests(tests)
+message(STATUS "Tests: ${CMAKE_CURRENT_SOURCE_DIR}")

--- a/tests/utils/test_logger.cpp
+++ b/tests/utils/test_logger.cpp
@@ -3,7 +3,6 @@
 #include <fstream>
 #include <string>
 
-using namespace newton;
 
 TEST_CASE("Logger basic functionality", "[utils]") {
   auto& logger = Logger::get_instance();
@@ -11,7 +10,7 @@ TEST_CASE("Logger basic functionality", "[utils]") {
 
   SECTION("info logging") {
     logger.enable(Logger::Level::INFO);
-    newton::Logger::LOG_INFO("Test", "Info message");
+    Logger::LOG_INFO("Test", "Info message");
 
 
     std::ifstream file("test.log");

--- a/tests/utils/test_message.cpp
+++ b/tests/utils/test_message.cpp
@@ -1,0 +1,200 @@
+#include <catch2/catch_test_macros.hpp>
+#include "message.h"
+#include "logger.h"
+
+struct TestInit {
+  TestInit() {
+    Logger::get_instance().enable_all();
+    Logger::LOG_INFO("MessageTest", "Starting message test suite");
+  }
+  ~TestInit() {
+    Logger::LOG_INFO("MessageTest", "Message test suite completed");
+  }
+};
+
+static TestInit testInit;
+
+TEST_CASE("Message memory layout", "[message]") {
+  Logger::LOG_INFO("MessageTest", "Testing message memory layout");
+
+  SECTION("constant validation") {
+    Logger::LOG_DEBUG("MessageTest", "Validating memory constants");
+    Logger::LOG_INFO("MessageTest", "Header size: %d", Message::HEADER_SIZE);
+    Logger::LOG_INFO("MessageTest", "Footer size: %d", Message::FOOTER_SIZE);
+    Logger::LOG_INFO("MessageTest", "Max payload: %d", Message::MAX_PAYLOAD_LENGTH);
+    Logger::LOG_INFO("MessageTest", "Buffer capacity: %d", Message::BUFER_CAPACITY);
+
+    REQUIRE(Message::HEADER_SIZE == sizeof(MessageHeader));
+    REQUIRE(Message::FOOTER_SIZE == sizeof(MessageFooter));
+    REQUIRE(Message::MAX_PAYLOAD_LENGTH == Message::BUFER_CAPACITY - Message::HEADER_SIZE - Message::FOOTER_SIZE);
+
+    Logger::LOG_INFO("MessageTest", "Memory constants validated successfully");
+  }
+
+  SECTION("offsets validation") {
+    Logger::LOG_DEBUG("MessageTest", "Validating memory offsets");
+    Logger::LOG_INFO("MessageTest", "Header offset: %d", Message::HEADER_OFFSET);
+    Logger::LOG_INFO("MessageTest", "Payload offset: %d", Message::PAYLOAD_OFFSET);
+
+    REQUIRE(Message::HEADER_OFFSET == 0);
+    REQUIRE(Message::PAYLOAD_OFFSET == Message::HEADER_SIZE);
+
+    Logger::LOG_INFO("MessageTest", "Memory offsets validated successfully");
+  }
+}
+
+TEST_CASE("Message basic serialization", "[message]") {
+  Logger::LOG_INFO("MessageTest", "Testing basic message serialization");
+
+  Message msg(1234567, MessageType::MOTOR_COMMAND);
+  MotorCommand cmd{
+      .motor_id = 1,
+      .motor_speed_x = 100,
+      .motor_speed_y = 150,
+      .motor_speed = 200
+  };
+
+  Logger::LOG_DEBUG("MessageTest", "Created test message with:");
+  Logger::LOG_DEBUG("MessageTest", "  Motor ID: %d", cmd.motor_id);
+  Logger::LOG_DEBUG("MessageTest", "  Speed X: %d", cmd.motor_speed_x);
+  Logger::LOG_DEBUG("MessageTest", "  Speed Y: %d", cmd.motor_speed_y);
+  Logger::LOG_DEBUG("MessageTest", "  Speed: %d", cmd.motor_speed);
+
+  SECTION("serialization results") {
+    Logger::LOG_INFO("MessageTest", "Testing message serialization");
+
+    int length = msg.serialize(&cmd, sizeof(MotorCommand));
+    Logger::LOG_INFO("MessageTest", "Serialized length: %d bytes", length);
+
+    int expected_length = Message::HEADER_SIZE + sizeof(MotorCommand) + Message::FOOTER_SIZE;
+    Logger::LOG_INFO("MessageTest", "Expected length: %d bytes", expected_length);
+
+    REQUIRE(length == expected_length);
+
+    MessageHeader hdr = msg.get_header();
+    Logger::LOG_DEBUG("MessageTest", "Header validation:");
+    Logger::LOG_DEBUG("MessageTest", "  Frame start: 0x%02X", hdr.frame_start);
+    Logger::LOG_DEBUG("MessageTest", "  Timestamp: %u", hdr.timestamp_ns);
+    Logger::LOG_DEBUG("MessageTest", "  Message type: 0x%02X", static_cast<uint8_t>(hdr.msg_type));
+    Logger::LOG_DEBUG("MessageTest", "  Payload length: %u", hdr.payload_length);
+
+    REQUIRE(hdr.frame_start == Message::FRAME_START_MARKER);
+    REQUIRE(hdr.timestamp_ns == 1234567);
+    REQUIRE(hdr.msg_type == MessageType::MOTOR_COMMAND);
+    REQUIRE(hdr.payload_length == sizeof(MotorCommand));
+
+    MessageFooter ftr = msg.get_footer();
+    Logger::LOG_DEBUG("MessageTest", "Footer validation:");
+    Logger::LOG_DEBUG("MessageTest", "  Frame end: 0x%02X", ftr.frame_end);
+    Logger::LOG_DEBUG("MessageTest", "  Checksum: 0x%04X", ftr.checksum);
+
+    REQUIRE(ftr.frame_end == Message::FRAME_END_MARKER);
+
+    Logger::LOG_INFO("MessageTest", "Serialization test completed successfully");
+  }
+}
+
+TEST_CASE("Message CRC verification", "[message]") {
+  Logger::LOG_INFO("MessageTest", "Testing message CRC verification");
+
+  Message msg(1234567, MessageType::MOTOR_COMMAND);
+  MotorCommand cmd{
+      .motor_id = 1,
+      .motor_speed_x = 100,
+      .motor_speed_y = 150,
+      .motor_speed = 200
+  };
+
+  SECTION("CRC calculation") {
+    Logger::LOG_DEBUG("MessageTest", "Starting CRC calculation test");
+
+    msg.serialize(&cmd, sizeof(MotorCommand));
+    Logger::LOG_DEBUG("MessageTest", "Message serialized, calculating CRC");
+
+    uint16_t manual_crc = 0;
+    const uint8_t* payload_data = msg.payload + Message::PAYLOAD_OFFSET;
+    Logger::LOG_DEBUG("MessageTest", "Payload data at offset: %d", Message::PAYLOAD_OFFSET);
+
+    for (size_t i = 0; i < sizeof(MotorCommand); i++) {
+      manual_crc ^= payload_data[i];
+      Logger::LOG_DEBUG("MessageTest", "CRC byte %zu: 0x%02X, running CRC: 0x%04X",
+        i, payload_data[i], manual_crc);
+    }
+
+    MessageFooter ftr = msg.get_footer();
+    Logger::LOG_INFO("MessageTest", "Manual CRC: 0x%04X", manual_crc);
+    Logger::LOG_INFO("MessageTest", "Stored CRC: 0x%04X", ftr.checksum);
+    Logger::LOG_INFO("MessageTest", "Calculated CRC: 0x%04X", msg.calculate_crc());
+
+    REQUIRE(ftr.checksum == manual_crc);
+    REQUIRE(ftr.checksum == msg.calculate_crc());
+
+    Logger::LOG_INFO("MessageTest", "CRC verification completed successfully");
+  }
+}
+
+TEST_CASE("Message round-trip serialization", "[message]") {
+  Logger::LOG_INFO("MessageTest", "Testing message round-trip serialization");
+
+  Message msg(1234567, MessageType::MOTOR_COMMAND);
+  MotorCommand original{
+      .motor_id = 1,
+      .motor_speed_x = 100,
+      .motor_speed_y = 150,
+      .motor_speed = 200
+  };
+
+  Logger::LOG_DEBUG("MessageTest", "Original command values:");
+  Logger::LOG_DEBUG("MessageTest", "  Motor ID: %d", original.motor_id);
+  Logger::LOG_DEBUG("MessageTest", "  Speed X: %d", original.motor_speed_x);
+  Logger::LOG_DEBUG("MessageTest", "  Speed Y: %d", original.motor_speed_y);
+  Logger::LOG_DEBUG("MessageTest", "  Speed: %d", original.motor_speed);
+
+  int serialized_len = msg.serialize(&original, sizeof(MotorCommand));
+  Logger::LOG_INFO("MessageTest", "Serialized message length: %d bytes", serialized_len);
+
+  MotorCommand deserialized;
+  msg.deserialize(&deserialized, sizeof(MotorCommand));
+
+  Logger::LOG_DEBUG("MessageTest", "Deserialized command values:");
+  Logger::LOG_DEBUG("MessageTest", "  Motor ID: %d", deserialized.motor_id);
+  Logger::LOG_DEBUG("MessageTest", "  Speed X: %d", deserialized.motor_speed_x);
+  Logger::LOG_DEBUG("MessageTest", "  Speed Y: %d", deserialized.motor_speed_y);
+  Logger::LOG_DEBUG("MessageTest", "  Speed: %d", deserialized.motor_speed);
+
+  int compare_result = memcmp(&original, &deserialized, sizeof(MotorCommand));
+  Logger::LOG_INFO("MessageTest", "Memory comparison result: %d", compare_result);
+
+  REQUIRE(compare_result == 0);
+  Logger::LOG_INFO("MessageTest", "Round-trip serialization test completed successfully");
+}
+
+TEST_CASE("Message corruption detection", "[message]") {
+  Logger::LOG_INFO("MessageTest", "Testing message corruption detection");
+
+  Message msg(1234567, MessageType::MOTOR_COMMAND);
+  MotorCommand cmd{
+      .motor_id = 1,
+      .motor_speed_x = 100,
+      .motor_speed_y = 150,
+      .motor_speed = 200
+  };
+
+  msg.serialize(&cmd, sizeof(MotorCommand));
+  uint16_t original_crc = msg.calculate_crc();
+  Logger::LOG_INFO("MessageTest", "Original CRC: 0x%04X", original_crc);
+
+  SECTION("payload corruption") {
+    Logger::LOG_DEBUG("MessageTest", "Corrupting payload at offset %d", Message::PAYLOAD_OFFSET);
+    Logger::LOG_DEBUG("MessageTest", "Original byte: 0x%02X", msg.payload[Message::PAYLOAD_OFFSET]);
+
+    msg.payload[Message::PAYLOAD_OFFSET] ^= 0xFF;
+    Logger::LOG_DEBUG("MessageTest", "Corrupted byte: 0x%02X", msg.payload[Message::PAYLOAD_OFFSET]);
+
+    uint16_t corrupted_crc = msg.calculate_crc();
+    Logger::LOG_INFO("MessageTest", "Corrupted CRC: 0x%04X", corrupted_crc);
+
+    REQUIRE(corrupted_crc != original_crc);
+    Logger::LOG_INFO("MessageTest", "Corruption detection test completed successfully");
+  }
+}

--- a/utils/include/logger.h
+++ b/utils/include/logger.h
@@ -8,142 +8,140 @@
 #include <fstream>
 #include <time.h>
 
-namespace newton {
-    class Logger {
-    public:
-        enum class Level {
-            DEBUG,
-            INFO,
-            WARN,
-            ERROR,
-            COUNT
-        };
-
-        template<typename... Args>
-        static void LOG_DEBUG(const std::string& tag, const char* format, Args... args) {
-            if (get_instance().is_enabled(Level::DEBUG)) {
-                auto& logger = get_instance();
-                logger.log_formatted(Level::DEBUG, tag, format, std::forward<Args>(args)...);
-            }
-        }
-
-        template<typename... Args>
-        static void LOG_INFO(const std::string& tag, const char* format, Args... args) {
-            if (get_instance().is_enabled(Level::INFO)) {
-                auto& logger = get_instance();
-                logger.log_formatted(Level::INFO, tag, format, std::forward<Args>(args)...);
-            }
-        }
-
-        template<typename... Args>
-        static void LOG_WARN(const std::string& tag, const char* format, Args... args) {
-            if (get_instance().is_enabled(Level::WARN)) {
-                auto& logger = get_instance();
-                logger.log_formatted(Level::WARN, tag, format, std::forward<Args>(args)...);
-            }
-        }
-
-        template<typename... Args>
-        static void LOG_ERROR(const std::string& tag, const char* format, Args... args) {
-            if (get_instance().is_enabled(Level::ERROR)) {
-                auto& logger = get_instance();
-                logger.log_formatted(Level::ERROR, tag, format, std::forward<Args>(args)...);
-            }
-        }
-
-        // Configuration methods
-        void set_logfile(const std::string& filename) {
-            std::lock_guard<std::mutex> lock(mutex);
-            logFile_ = filename;
-        }
-
-        void enable(Level level) {
-            enabled_levels.set(static_cast<size_t>(level), true);
-        }
-
-        void disable(Level level) {
-            enabled_levels.set(static_cast<size_t>(level), false);
-        }
-
-        bool is_enabled(Level level) const {
-            return enabled_levels[static_cast<size_t>(level)];
-        }
-
-        void enable_all() {
-            enabled_levels.set();
-        }
-
-        void disable_all() {
-            enabled_levels.reset();
-        }
-
-        static Logger& get_instance() {
-            static Logger instance;
-            return instance;
-        }
-
-    private:
-        Logger() {
-            enable_all();
-            disable(Level::DEBUG);
-        }
-
-        Logger(const Logger&) = delete;
-        Logger& operator=(const Logger&) = delete;
-
-        template<typename... Args>
-        void log_formatted(Level level, const std::string& tag, const char* format, Args... args) {
-            std::lock_guard<std::mutex> lock(mutex);
-
-            // Format the message
-            char buffer[1024];
-            snprintf(buffer, sizeof(buffer), format, std::forward<Args>(args)...);
-
-            std::stringstream ss;
-            ss << get_timestamp();
-            ss << " [ " << to_string(level) << " ]";
-            ss << " [ " << tag << " ] ";
-            ss << buffer;
-
-            // Output to console
-            std::cout << ss.str() << std::endl;
-
-            // Output to file if configured
-            if (!logFile_.empty()) {
-                std::ofstream file(logFile_, std::ios::app);
-                if (file.is_open()) {
-                    file << ss.str() << std::endl;
-                    file.flush();
-                }
-            }
-        }
-
-        std::string get_timestamp() {
-            auto now = std::chrono::system_clock::now();
-            auto now_c = std::chrono::system_clock::to_time_t(now);
-            auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                now.time_since_epoch()) % 1000;
-
-            struct tm* timeinfo = localtime(&now_c);
-            char buffer[24];  // Enough for "YYYY-MM-DD HH:MM:SS.mmm"
-            strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S", timeinfo);
-
-            sprintf(buffer + strlen(buffer), ".%03ld", now_ms.count());
-
-            return std::string(buffer);
-        }
-        std::string to_string(Level level) {
-            switch (level) {
-            case Level::DEBUG:   return "DEBUG";
-            case Level::INFO:    return "INFO ";
-            case Level::WARN:    return "WARN ";
-            case Level::ERROR:   return "ERROR";
-            default:            return "UNKNOWN";
-            }
-        }
-
-        std::bitset<static_cast<size_t>(Level::COUNT)> enabled_levels;
-        std::mutex mutex;
-        std::string logFile_;
+class Logger {
+public:
+    enum class Level {
+        DEBUG,
+        INFO,
+        WARN,
+        ERROR,
+        COUNT
     };
-} // namespace log
+
+    template<typename... Args>
+    static void LOG_DEBUG(const std::string& tag, const char* format, Args... args) {
+        if (get_instance().is_enabled(Level::DEBUG)) {
+            auto& logger = get_instance();
+            logger.log_formatted(Level::DEBUG, tag, format, std::forward<Args>(args)...);
+        }
+    }
+
+    template<typename... Args>
+    static void LOG_INFO(const std::string& tag, const char* format, Args... args) {
+        if (get_instance().is_enabled(Level::INFO)) {
+            auto& logger = get_instance();
+            logger.log_formatted(Level::INFO, tag, format, std::forward<Args>(args)...);
+        }
+    }
+
+    template<typename... Args>
+    static void LOG_WARN(const std::string& tag, const char* format, Args... args) {
+        if (get_instance().is_enabled(Level::WARN)) {
+            auto& logger = get_instance();
+            logger.log_formatted(Level::WARN, tag, format, std::forward<Args>(args)...);
+        }
+    }
+
+    template<typename... Args>
+    static void LOG_ERROR(const std::string& tag, const char* format, Args... args) {
+        if (get_instance().is_enabled(Level::ERROR)) {
+            auto& logger = get_instance();
+            logger.log_formatted(Level::ERROR, tag, format, std::forward<Args>(args)...);
+        }
+    }
+
+// Configuration methods
+    void set_logfile(const std::string& filename) {
+        std::lock_guard<std::mutex> lock(mutex);
+        log_file = filename;
+    }
+
+    void enable(Level level) {
+        enabled_levels.set(static_cast<size_t>(level), true);
+    }
+
+    void disable(Level level) {
+        enabled_levels.set(static_cast<size_t>(level), false);
+    }
+
+    bool is_enabled(Level level) const {
+        return enabled_levels[static_cast<size_t>(level)];
+    }
+
+    void enable_all() {
+        enabled_levels.set();
+    }
+
+    void disable_all() {
+        enabled_levels.reset();
+    }
+
+    static Logger& get_instance() {
+        static Logger instance;
+        return instance;
+    }
+
+private:
+    Logger() {
+        enable_all();
+        disable(Level::DEBUG);
+    }
+
+    Logger(const Logger&) = delete;
+    Logger& operator=(const Logger&) = delete;
+
+    template<typename... Args>
+    void log_formatted(Level level, const std::string& tag, const char* format, Args... args) {
+        std::lock_guard<std::mutex> lock(mutex);
+
+        // Format the message
+        char buffer[1024];
+        snprintf(buffer, sizeof(buffer), format, std::forward<Args>(args)...);
+
+        std::stringstream ss;
+        ss << get_timestamp();
+        ss << " [ " << to_string(level) << " ]";
+        ss << " [ " << tag << " ] ";
+        ss << buffer;
+
+        // Output to console
+        std::cout << ss.str() << std::endl;
+
+    // Output to file if configured
+        if (!log_file.empty()) {
+            std::ofstream file(log_file, std::ios::app);
+            if (file.is_open()) {
+                file << ss.str() << std::endl;
+                file.flush();
+            }
+        }
+    }
+
+    std::string get_timestamp() {
+        auto now = std::chrono::system_clock::now();
+        auto now_c = std::chrono::system_clock::to_time_t(now);
+        auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+            now.time_since_epoch()) % 1000;
+
+        struct tm* timeinfo = localtime(&now_c);
+        char buffer[24];  // Enough for "YYYY-MM-DD HH:MM:SS.mmm"
+        strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S", timeinfo);
+
+        sprintf(buffer + strlen(buffer), ".%03ld", now_ms.count());
+
+        return std::string(buffer);
+    }
+    std::string to_string(Level level) {
+        switch (level) {
+        case Level::DEBUG:   return "DEBUG";
+        case Level::INFO:    return "INFO ";
+        case Level::WARN:    return "WARN ";
+        case Level::ERROR:   return "ERROR";
+        default:            return "UNKNOWN";
+        }
+    }
+
+    std::bitset<static_cast<size_t>(Level::COUNT)> enabled_levels;
+    std::mutex mutex;
+    std::string log_file;
+};


### PR DESCRIPTION
This PR adds a new message serialization system for motor control communication. The system provides a structured way to send and receive motor commands with built-in error detection.

## Features

- Fixed message framing with start/end markers
- CRC-based error detection
- Timestamp support
- Compact binary serialization
- Comprehensive test coverage
- Debug utilities (hex dump, debug printing)

## Message Types

Currently supported message types:
- `SYNC`: Synchronization messages
- `MOTOR_COMMAND`: Motor control commands
- `MOTOR_STATE`: Motor status feedback
- `RESYNC`: Re-synchronization request

## Usage Examples

### Basic Motor Command

```cpp
// Create a motor command message
Message msg(get_timestamp_ns(), MessageType::MOTOR_COMMAND);
MotorCommand cmd{
    .motor_id = 1,
    .motor_speed_x = 100,
    .motor_speed_y = 150,
    .motor_speed = 200
};

// Serialize the command
int length = msg.serialize(&cmd, sizeof(MotorCommand));

// Send the serialized data
// uart.write(msg.payload, length);

// Optional: Debug print the message
msg.print_debug();
```

### Reading Motor State

```cpp
// Create a message for incoming data
Message msg(get_timestamp_ns(), MessageType::MOTOR_STATE);
MotorState state;

// Assuming data was received into msg.payload
msg.deserialize(&state, sizeof(MotorState));

// Access the motor state
printf("Motor %d speed: %d\n", state.motor_id, state.current_speed);
if (state.error_flags) {
    printf("Motor error flags: 0x%02X\n", state.error_flags);
}
```

## Adding New Message Types

To add a new message type:

1. Add the type to the `MessageType` enum:
```cpp
enum class MessageType : uint8_t {
    SYNC = 0x00,
    MOTOR_COMMAND = 0x01,
    MOTOR_STATE = 0x02,
    RESYNC = 0x03,
    NEW_TYPE = 0x04  // Add your new type here
};
```

2. Define your message structure:
```cpp
#pragma pack(push, 1)
struct NewMessageType {
    uint8_t field1;
    uint16_t field2;
    // ... add your fields
};
#pragma pack(pop)
```

Note: Always use `#pragma pack(1)` to ensure proper byte alignment.

## Testing

Comprehensive tests are included in `tests/utils/test_message.cpp`. Run the tests with:

```bash
mkdir build && cd build
cmake -DENABLE_TESTING=ON ..
make
./tests
```